### PR TITLE
Fix a Python syntax error in polynomial.py

### DIFF
--- a/数据结构/labs/2017/polynomial/polynomial.py
+++ b/数据结构/labs/2017/polynomial/polynomial.py
@@ -148,9 +148,10 @@ def menu():
     print('8.cal val')
     print('9.polynomial iter')
     print('10.menu')
-    primt('11.exit')
+    print('11.exit')
 
 def go():
     menu()
     
-if __name__ = '__main__':
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/USTC-Resource/USTC-Course on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./算法基础/labs/2018-徐云/lab1/PB16030899-朱河勤-实验一.py:11:16: F821 undefined name 'pont'
        return pont(-self.x, -self.y)
               ^
./数理逻辑/codes/mbinary/system_L.py:220:23: E999 TabError: inconsistent use of tabs and spaces in indentation
	s=s.replace('<->','-')
                      ^
./数据结构/codes/mbinary/graph/directed.py:49:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/codes/mbinary/graph/directed.py:49:22: F821 undefined name 'i'
        self.vertexs[i]= x
                     ^
./数据结构/codes/mbinary/graph/adjacentList.py:55:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/codes/mbinary/graph/adjacentList.py:104:33: F821 undefined name 'e'
            while arc.nextEdge!=e:
                                ^
./数据结构/codes/mbinary/graph/adjacentList.py:112:41: F821 undefined name 'e'
                    while arc.nextEdge!=e:
                                        ^
./数据结构/codes/mbinary/graph/undirected.py:60:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/graph.py:52:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/directed.py:39:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/directed.py:39:22: F821 undefined name 'i'
        self.vertexs[i]= x
                     ^
./数据结构/labs/2017/polynomial/polynomial.py:156:13: E999 SyntaxError: invalid syntax
if __name__ = '__main__':
            ^
2     E999 SyntaxError: invalid syntax
10    F821 undefined name 'self'
12
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree