### PR TITLE
Travis CI: Simplify using language: 'python'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
-language: python3
-sudo: required
-python: 
-  - "3.6"
+language: python
+python: "3.6"
 
-notifications:
-  email:
-    recipients:
-      - zhuheqin1@gmail.com
-    on_success: change # default: change
-    on_failure: always # default: always
+branches:
+  only:
+    - master
+
+env:
+  # Github Pages
+  - GH_REF: github.com/USTC-Resource/USTC-Course
 
 install:
-  - sudo apt-get install python3 -y
-  - sudo apt-get install python3-pip -y
-  - sudo pip3 install markdown 
-  - sudo pip3 install pypinyin
+  - pip install --upgrade pip
+  - pip install markdown pypinyin
 
 script:
-  - python3 utils/genReadme.py
-  - python3 utils/genIndex.py
+  - python utils/genReadme.py
+  - python utils/genIndex.py
 
 after_script:
   # Build Master Repository(Coding Pages) 
@@ -31,15 +28,9 @@ after_script:
   - git commit -m "Travis-CI Update pages with build $TRAVIS_BUILD_NUMBER"
   - git push -f "https://${GH_TOKEN}@${GH_REF}" master:gh-pages
 
-addons:
-  apt:
-    update: true
-
-branches:
-  only:
-    - master
-env:
- global:
-   # Github Pages
-   - GH_REF: github.com/USTC-Resource/USTC-Course
-
+notifications:
+  email:
+    recipients:
+      - zhuheqin1@gmail.com
+    on_success: change # default: change
+    on_failure: always # default: always


### PR DESCRIPTION
__language: python3__ does not exist in Travis which is why __apt install__ was required.  Using __language: python__ instead will automate the installation of both Python 3.6 and pip.