### PR TITLE
Travis CI: Use flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ env:
 
 install:
   - pip install --upgrade pip
-  - pip install markdown pypinyin
+  - pip install flake8 markdown pypinyin
 
 script:
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   - python utils/genReadme.py
   - python utils/genIndex.py
 

--- a/数据结构/codes/mbinary/graph/adjacentList.py
+++ b/数据结构/codes/mbinary/graph/adjacentList.py
@@ -51,7 +51,7 @@ class graph:
         self.edges = {}
     def __getitem__(self,i): 
         return self.vertexs[i]
-    def __setitem__(selfi,x):
+    def __setitem__(self, i,x):
         self.vertexs[i]= x
     def __iter__(self):
         return iter(self.vertexs)

--- a/数据结构/codes/mbinary/graph/directed.py
+++ b/数据结构/codes/mbinary/graph/directed.py
@@ -45,7 +45,7 @@ class graph:
         self.edges = {}
     def __getitem__(self,i): 
         return self.vertexs[i]
-    def __setitem__(selfi,x):
+    def __setitem__(self,i,x):
         self.vertexs[i]= x
     def __iter__(self):
         return iter(self.vertexs.values())

--- a/数据结构/codes/mbinary/graph/undirected.py
+++ b/数据结构/codes/mbinary/graph/undirected.py
@@ -56,7 +56,7 @@ class graph:
         self.edges = {}
     def __getitem__(self,i): 
         return self.vertexs[i]
-    def __setitem__(selfi,x):
+    def __setitem__(self,i,x):
         self.vertexs[i]= x
     def __iter__(self):
         return iter(self.vertexs)

--- a/数据结构/labs/2017/navigation/directed.py
+++ b/数据结构/labs/2017/navigation/directed.py
@@ -35,7 +35,7 @@ class graph:
         self.edges = {}
     def __getitem__(self,i): 
         return self.vertexs[i]
-    def __setitem__(selfi,x):
+    def __setitem__(self,i,x):
         self.vertexs[i]= x
     def __iter__(self):
         return iter(self.vertexs.values())

--- a/数据结构/labs/2017/navigation/graph.py
+++ b/数据结构/labs/2017/navigation/graph.py
@@ -48,7 +48,7 @@ class graph:
         self.edges = {}
     def __getitem__(self,i): 
         return self.vertexs[i]
-    def __setitem__(selfi,x):
+    def __setitem__(self,i,x):
         self.vertexs[i]= x
     def __iter__(self):
         return iter(self.vertexs)

--- a/数理逻辑/codes/mbinary/system_L.py
+++ b/数理逻辑/codes/mbinary/system_L.py
@@ -29,9 +29,9 @@ from collections import namedtuple
 
 NON = sympy.Symbol('~')
 CONTAIN = sympy.Symbol('>')
-AND = sympy .Symbol('&')
-OR = sysmpy.Symbol('|')
-EQUAL = sysmpy.Symbol('-')
+AND = sympy.Symbol('&')
+OR = sympy.Symbol('|')
+EQUAL = sympy.Symbol('-')
 LEFT = sympy.Symbol('(')
 RIGHT = sympy.Symbol(')')
 

--- a/数理逻辑/codes/mbinary/system_L.py
+++ b/数理逻辑/codes/mbinary/system_L.py
@@ -216,8 +216,8 @@ class  system_L:
         right = contain(p,q)
         return contain(left,right)
     def genFormula(self,s:str)->formula:
-        s=s.replace('~~','')  #  simplify the deduction,  to do
-	s=s.replace('<->','-')
+	    s=s.replace('~~','')  #  simplify the deduction,  to do
+	    s=s.replace('<->','-')
         s=s.replace('->','>')
         li = re.findall(r'[\(\)\>\~]|\w+',s)
         li = [sympy.Symbol(i) for i in li]

--- a/数理逻辑/codes/mbinary/system_L.py
+++ b/数理逻辑/codes/mbinary/system_L.py
@@ -216,8 +216,8 @@ class  system_L:
         right = contain(p,q)
         return contain(left,right)
     def genFormula(self,s:str)->formula:
-	    s=s.replace('~~','')  #  simplify the deduction,  to do
-	    s=s.replace('<->','-')
+        s=s.replace('~~','')  #  simplify the deduction,  to do
+        s=s.replace('<->','-')
         s=s.replace('->','>')
         li = re.findall(r'[\(\)\>\~]|\w+',s)
         li = [sympy.Symbol(i) for i in li]


### PR DESCRIPTION
Blocked by #9.   Fixed 8 out of 10 but I can not find the solution to the other 2...
* https://github.com/USTC-Resource/USTC-Course/blob/master/%E6%95%B0%E6%8D%AE%E7%BB%93%E6%9E%84/codes/mbinary/graph/adjacentList.py#L104-L112

[flake8](http://flake8.pycqa.org) testing of https://github.com/USTC-Resource/USTC-Course on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./数理逻辑/codes/mbinary/system_L.py:220:23: E999 TabError: inconsistent use of tabs and spaces in indentation
	s=s.replace('<->','-')
                      ^
./数据结构/codes/mbinary/graph/directed.py:49:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/codes/mbinary/graph/directed.py:49:22: F821 undefined name 'i'
        self.vertexs[i]= x
                     ^
./数据结构/codes/mbinary/graph/adjacentList.py:55:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/codes/mbinary/graph/adjacentList.py:104:33: F821 undefined name 'e'
            while arc.nextEdge!=e:
                                ^
./数据结构/codes/mbinary/graph/adjacentList.py:112:41: F821 undefined name 'e'
                    while arc.nextEdge!=e:
                                        ^
./数据结构/codes/mbinary/graph/undirected.py:60:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/graph.py:52:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/directed.py:39:9: F821 undefined name 'self'
        self.vertexs[i]= x
        ^
./数据结构/labs/2017/navigation/directed.py:39:22: F821 undefined name 'i'
        self.vertexs[i]= x
                     ^
1     E999 TabError: inconsistent use of tabs and spaces in indentation
9     F821 undefined name 'self'
10
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
